### PR TITLE
Fixes RandomSplitterImpl return type bug. 

### DIFF
--- a/src/data_hub/dataset/iterator.py
+++ b/src/data_hub/dataset/iterator.py
@@ -1,19 +1,48 @@
-from abc import ABC, abstractmethod
+from typing import Sequence, List
 
 
-class DatasetIteratorIF(ABC):
+class DatasetIteratorIF:
 
-    def __init__(self, dataset_name: str):
+    def __init__(self, dataset_sequences: List[Sequence], dataset_name: str = None, dataset_tag: str = None):
         self._dataset_name = dataset_name
+        self._dataset_sequences = dataset_sequences
+        self._dataset_tag = dataset_tag
 
-    @abstractmethod
     def __len__(self):
-        raise NotImplementedError
+        return len(self._dataset_sequences[0])
 
-    @abstractmethod
     def __getitem__(self, index: int):
-        raise NotImplementedError
+        return tuple([s[index] for s in self._dataset_sequences])
 
     @property
     def dataset_name(self) -> str:
         return self._dataset_name
+
+    @property
+    def dataset_tag(self) -> str:
+        return self._dataset_tag
+
+
+class SplittedDatasetIteratorIF:
+    """Provides a view on a `DatasetIterator` for accessing elements of a given split only."""
+
+    def __init__(self, dataset_iterator: DatasetIteratorIF, indices: List[int], dataset_tag: str = None):
+        self._dataset_name = dataset_iterator.dataset_name
+        self._dataset_iterator = dataset_iterator
+        self._indices = indices
+        self._dataset_tag = dataset_tag
+
+    def __len__(self):
+        return len(self.indices)
+
+    def __getitem__(self, index: int):
+        original_dataset_index = self._indices[index]
+        return self._dataset_iterator[original_dataset_index]
+
+    @property
+    def dataset_name(self) -> str:
+        return self._dataset_name
+
+    @property
+    def dataset_tag(self) -> str:
+        return self._dataset_tag

--- a/src/data_hub/dataset/splitter.py
+++ b/src/data_hub/dataset/splitter.py
@@ -1,4 +1,4 @@
-from data_hub.dataset.iterator import DatasetIteratorIF
+from data_hub.dataset.iterator import DatasetIteratorIF, SplittedDatasetIteratorIF
 from typing import List
 from abc import ABC, abstractmethod
 import random
@@ -30,13 +30,15 @@ class Splitter(SplitterIF):
 
 class RandomSplitterImpl(SplitterIF):
 
-    def __init__(self, ratios: List[float]):
+    def __init__(self, ratios: List[float], split_names: List[str] = None):
         self.ratios = ratios
+        self.split_names = split_names if split_names is not None else [None]*len(ratios)
 
     def split(self, dataset_iterator: DatasetIteratorIF) -> List[DatasetIteratorIF]:
         dataset_length = len(dataset_iterator)
         splits_indices = RandomSplitterImpl._determine_split_indices(dataset_length, self.ratios)
-        return [itemgetter(*split_indices)(dataset_iterator) for split_indices in splits_indices]
+        return [SplittedDatasetIteratorIF(dataset_iterator, split_indices, split_name)
+                for split_indices, split_name in zip(splits_indices, self.split_names)]
 
     @staticmethod
     def _determine_split_indices(dataset_length: int, ratios: List[int]) -> List[List[int]]:

--- a/src/data_hub/mnist/iterator.py
+++ b/src/data_hub/mnist/iterator.py
@@ -8,16 +8,5 @@ class MNISTIterator(DatasetIteratorIF):
     """
 
     def __init__(self, samples_stream: StreamedResource, targets_stream: StreamedResource = None):
-        super().__init__(dataset_name="MNIST")
-        self.samples = torch.load(samples_stream)
-        self.targets = torch.load(targets_stream)
-
-    def __len__(self):
-        return len(self.samples)
-
-    def __getitem__(self, index: int):
-        """ Returns the sample and target of the dataset at given index position.
-        :param index: index within dataset
-        :return: sample, target
-        """
-        return self.samples[index], self.targets[index]
+        dataset_sequences = [torch.load(samples_stream), torch.load(targets_stream)]
+        super().__init__(dataset_name="MNIST", dataset_sequences=dataset_sequences)

--- a/unittests/dataset/test_splitter.py
+++ b/unittests/dataset/test_splitter.py
@@ -4,18 +4,6 @@ from typing import List
 from data_hub.dataset.splitter import RandomSplitterImpl, Splitter
 
 
-class MockedDatasetIterator(DatasetIteratorIF):
-    def __init__(self):
-        self.data = list(range(1000))
-
-    def __len__(self):
-        return len(self.data)
-
-    def __getitem__(self, index):
-
-        return self.data[index]
-
-
 class TestSplitter:
     @pytest.fixture
     def ratios(self) -> List[int]:
@@ -23,7 +11,9 @@ class TestSplitter:
 
     @pytest.fixture
     def dataset_iterator(self) -> DatasetIteratorIF:
-        return MockedDatasetIterator()
+        return DatasetIteratorIF(dataset_sequences=[list(range(10)), list(range(10))],
+                                 dataset_name="N",
+                                 dataset_tag="t")
 
     def test_random_splitter(self, ratios: List[int], dataset_iterator: DatasetIteratorIF):
         splitter_impl = RandomSplitterImpl(ratios=ratios)


### PR DESCRIPTION
* `RandomSplitterImpl` uses `SplittedDatasetIteratorIF` instead of itemgetter. `SplittedDatasetIteratorIF` provides a Splitview on the original `DatasetIteratorIF`. 
* `DatasetIteratorIF` is now a fully implemented dataset iterator. Therefore, `MNISTDatasetIteratorIF` could be slimmed down. 
*  closes #1